### PR TITLE
Windows build: Iterate over possible InnoSetup install paths.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,24 +1,49 @@
-FROM python:3.10-alpine
+FROM python:3.10
 
-ENV TZ Europe/Amsterdam
+ENV TZ=Etc/UTC
+ENV DOCKER_HOST=unix:///var/run/user/1000/docker.sock
 
 ARG USERNAME=devcontainer
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
 # Install git, process tools, lsb-release (common in install instructions for CLIs) and curl
-RUN apk --no-cache update && apk --no-cache upgrade && \
-	apk add --no-cache gcc musl-dev linux-headers libffi-dev bash zsh git curl sudo build-base openssh-client
+# RUN apk --no-cache update && apk --no-cache upgrade && \
+# 	apk add --no-cache gcc musl-dev linux-headers libffi-dev bash zsh git curl sudo build-base openssh-client pkgconfig docker-cli gtk+3.0
+
+RUN apt-get update && apt-get install -y \
+	apt-utils \
+	locales \
+	locales-all \
+	ca-certificates \
+	curl \
+	git \
+	openssh-client \
+	procps \
+	sudo \
+	zsh \
+	gnupg \
+	lsb-release \
+	&& apt-get clean
 
 RUN pip install --no-cache-dir --upgrade pip && \
 	pip install --no-cache-dir wheel pre-commit
+
+RUN install -m 0755 -d /etc/apt/keyrings && \
+	curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc && \
+	chmod a+r /etc/apt/keyrings/docker.asc && \
+	echo \
+	"deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
+	$(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+	(sudo tee /etc/apt/sources.list.d/docker.list > /dev/null) && \
+	apt-get update && apt-get install -y docker-ce-cli docker-buildx-plugin docker-compose-plugin
 
 # change default shell from bash to zsh
 RUN sed -i -e "s/bin\/ash/bin\/zsh/" /etc/passwd
 
 # Create the user
-RUN addgroup -g $USER_GID $USERNAME \
-	&& adduser -D -u $USER_UID -G $USERNAME -s /bin/zsh $USERNAME
+RUN addgroup --gid $USER_GID $USERNAME \
+	&& adduser --gecos GECOS --disabled-password --uid $USER_UID --gid $USER_GID --shell /bin/zsh $USERNAME
 # add user to sudoer
 RUN echo "$USERNAME ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
@@ -33,3 +58,9 @@ RUN git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-~/.
 COPY config/zshrc /home/$USERNAME/.zshrc
 
 COPY config/gitconfig /home/$USERNAME/.gitconfig
+
+VOLUME [ "/workspaces/CrossMgr" ]
+
+WORKDIR /workspaces/CrossMgr
+
+RUN git config --global --add safe.directory /workspaces/CrossMgr

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,35 @@
+FROM python:3.10-alpine
+
+ENV TZ Europe/Amsterdam
+
+ARG USERNAME=devcontainer
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Install git, process tools, lsb-release (common in install instructions for CLIs) and curl
+RUN apk --no-cache update && apk --no-cache upgrade && \
+	apk add --no-cache gcc musl-dev linux-headers libffi-dev bash zsh git curl sudo build-base openssh-client
+
+RUN pip install --no-cache-dir --upgrade pip && \
+	pip install --no-cache-dir wheel pre-commit
+
+# change default shell from bash to zsh
+RUN sed -i -e "s/bin\/ash/bin\/zsh/" /etc/passwd
+
+# Create the user
+RUN addgroup -g $USER_GID $USERNAME \
+	&& adduser -D -u $USER_UID -G $USERNAME -s /bin/zsh $USERNAME
+# add user to sudoer
+RUN echo "$USERNAME ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+# change user
+USER $USERNAME
+
+# install oh-my-zsh
+RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+# install zsh plugins auto suggestions and syntax highlighting
+RUN git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
+
+COPY config/zshrc /home/$USERNAME/.zshrc
+
+COPY config/gitconfig /home/$USERNAME/.gitconfig

--- a/.devcontainer/config/gitconfig
+++ b/.devcontainer/config/gitconfig
@@ -1,0 +1,2 @@
+[init]
+        defaultBranch = master

--- a/.devcontainer/config/zshrc
+++ b/.devcontainer/config/zshrc
@@ -1,0 +1,109 @@
+# If you come from bash you might have to change your $PATH.
+# export PATH=$HOME/bin:/usr/local/bin:$PATH
+
+# Path to your oh-my-zsh installation.
+export ZSH="$HOME/.oh-my-zsh"
+
+# Set name of the theme to load --- if set to "random", it will
+# load a random theme each time oh-my-zsh is loaded, in which case,
+# to know which specific one was loaded, run: echo $RANDOM_THEME
+# See https://github.com/ohmyzsh/ohmyzsh/wiki/Themes
+ZSH_THEME="robbyrussell"
+
+# Set list of themes to pick from when loading at random
+# Setting this variable when ZSH_THEME=random will cause zsh to load
+# a theme from this variable instead of looking in $ZSH/themes/
+# If set to an empty array, this variable will have no effect.
+# ZSH_THEME_RANDOM_CANDIDATES=( "robbyrussell" "agnoster" )
+
+# Uncomment the following line to use case-sensitive completion.
+# CASE_SENSITIVE="true"
+
+# Uncomment the following line to use hyphen-insensitive completion.
+# Case-sensitive completion must be off. _ and - will be interchangeable.
+# HYPHEN_INSENSITIVE="true"
+
+# Uncomment one of the following lines to change the auto-update behavior
+# zstyle ':omz:update' mode disabled  # disable automatic updates
+# zstyle ':omz:update' mode auto      # update automatically without asking
+# zstyle ':omz:update' mode reminder  # just remind me to update when it's time
+
+# Uncomment the following line to change how often to auto-update (in days).
+# zstyle ':omz:update' frequency 13
+
+# Uncomment the following line if pasting URLs and other text is messed up.
+# DISABLE_MAGIC_FUNCTIONS="true"
+
+# Uncomment the following line to disable colors in ls.
+# DISABLE_LS_COLORS="true"
+
+# Uncomment the following line to disable auto-setting terminal title.
+# DISABLE_AUTO_TITLE="true"
+
+# Uncomment the following line to enable command auto-correction.
+# ENABLE_CORRECTION="true"
+
+# Uncomment the following line to display red dots whilst waiting for completion.
+# You can also set it to another string to have that shown instead of the default red dots.
+# e.g. COMPLETION_WAITING_DOTS="%F{yellow}waiting...%f"
+# Caution: this setting can cause issues with multiline prompts in zsh < 5.7.1 (see #5765)
+# COMPLETION_WAITING_DOTS="true"
+
+# Uncomment the following line if you want to disable marking untracked files
+# under VCS as dirty. This makes repository status check for large repositories
+# much, much faster.
+# DISABLE_UNTRACKED_FILES_DIRTY="true"
+
+# Uncomment the following line if you want to change the command execution time
+# stamp shown in the history command output.
+# You can set one of the optional three formats:
+# "mm/dd/yyyy"|"dd.mm.yyyy"|"yyyy-mm-dd"
+# or set a custom format using the strftime function format specifications,
+# see 'man strftime' for details.
+# HIST_STAMPS="mm/dd/yyyy"
+
+# Would you like to use another custom folder than $ZSH/custom?
+# ZSH_CUSTOM=/path/to/new-custom-folder
+
+# Which plugins would you like to load?
+# Standard plugins can be found in $ZSH/plugins/
+# Custom plugins may be added to $ZSH_CUSTOM/plugins/
+# Example format: plugins=(rails git textmate ruby lighthouse)
+# Add wisely, as too many plugins slow down shell startup.
+plugins=(
+    git
+    zsh-autosuggestions
+)
+
+ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=5'
+
+
+source $ZSH/oh-my-zsh.sh
+
+# User configuration
+
+# export MANPATH="/usr/local/man:$MANPATH"
+
+# You may need to manually set your language environment
+# export LANG=en_US.UTF-8
+
+# Preferred editor for local and remote sessions
+# if [[ -n $SSH_CONNECTION ]]; then
+#   export EDITOR='vim'
+# else
+#   export EDITOR='mvim'
+# fi
+
+# Compilation flags
+# export ARCHFLAGS="-arch x86_64"
+
+# Set personal aliases, overriding those provided by oh-my-zsh libs,
+# plugins, and themes. Aliases can be placed here, though oh-my-zsh
+# users are encouraged to define aliases within the ZSH_CUSTOM folder.
+# For a full list of active aliases, run `alias`.
+#
+# Example aliases
+# alias zshconfig="mate ~/.zshrc"
+# alias ohmyzsh="mate ~/.oh-my-zsh"
+export PATH=$PATH:/home/devcontainer/.local/bin/
+export ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=8'

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+{
+	"name": "Python DevContainer",
+	"dockerFile": "Dockerfile",
+	"customizations": {
+			"vscode": {
+					"settings": {
+							"editor.tabSize": 2,
+							"files.trimTrailingWhitespace": true,
+							"workbench.colorTheme": "Aura Dark",
+							"workbench.iconTheme": "material-icon-theme",
+							"files.exclude": {
+									".env": true,
+									".git": true,
+									".pytest**": true,
+									".vscode": true,
+									"**/__pycache__": true,
+									"**/.git": false,
+									"**/.vagrant": true,
+									"venv": true
+							}
+					},
+					"extensions": [
+							"ms-python.python",
+							"ms-python.vscode-pylance",
+							"DaltonMenezes.aura-theme",
+							"equinusocio.vsc-material-theme-icons",
+							"GitHub.copilot"
+					]
+			}
+	},
+	"remoteUser": "devcontainer",
+	"postCreateCommand": "bash -i -c 'pre-commit install && pip install -r requirements.txt'"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,12 @@
 {
-	"name": "Python DevContainer",
+	"name": "CrossMgr Python DevContainer",
 	"dockerFile": "Dockerfile",
+	"mounts": ["source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind"],
+	"runArgs": ["--add-host=host.docker.internal:host-gateway"],
 	"customizations": {
 			"vscode": {
 					"settings": {
+							"dev.containers.copyGitConfig": true,
 							"editor.tabSize": 2,
 							"files.trimTrailingWhitespace": true,
 							"workbench.colorTheme": "Aura Dark",
@@ -20,14 +23,15 @@
 							}
 					},
 					"extensions": [
-							"ms-python.python",
-							"ms-python.vscode-pylance",
-							"DaltonMenezes.aura-theme",
-							"equinusocio.vsc-material-theme-icons",
-							"GitHub.copilot"
+						"ms-python.python",
+						"ms-python.vscode-pylance",
+						"DaltonMenezes.aura-theme",
+						"equinusocio.vsc-material-theme-icons",
+						"GitHub.copilot",
+						"ms-azuretools.vscode-docker"
 					]
 			}
 	},
 	"remoteUser": "devcontainer",
-	"postCreateCommand": "bash -i -c 'pre-commit install && pip install -r requirements.txt'"
+	"postCreateCommand": "bash -i -c './linuxdeps.sh -y && pre-commit install && pip install -r requirements.txt'"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## vv3.0.44-20200103135644 (03/01/2020)
+
 - [Updated version.](https://github.com/esitarski/CrossMgr/commit/50bf878f66c9c5738f6abf44014a03e10769b78c) - @esitarski
 - [Fixed SetValue bug in HighPrecisionTimeEdit.](https://github.com/esitarski/CrossMgr/commit/7c8721ff317e0bb776daed24d5639a3fde3ca623) - @esitarski
 - [Fixed bug in Linux/MacOS initialization.](https://github.com/esitarski/CrossMgr/commit/80310a2d481658eca0b0faabe4b74727b915353a) - @esitarski

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-![](https://github.com/esitarski/CrossMgr/workflows/DevelopmentBuild/badge.svg)
-![](https://github.com/esitarski/CrossMgr/workflows/ReleaseBuild/badge.svg)
-
 # Cross Manager Race Scoring Software
+
+![Development Build status](https://github.com/esitarski/CrossMgr/workflows/DevelopmentBuild/badge.svg)
+![Release Build status](https://github.com/esitarski/CrossMgr/workflows/ReleaseBuild/badge.svg)
 
 Welcome to Cross Manager! Cross Manager is software used to score bike races. It has many features including support for RFID chip readers. Full documentation is in the CrossMgrHtml directory or under Help in the application.
 
@@ -33,21 +33,21 @@ The minimum system requires are as follows:
 
 ### Windows
 
-- Windows 11 x64
-- 4G RAM
-- 10G HD space
+* Windows 11 x64
+* 4G RAM
+* 10G HD space
 
 ### MacOSX
 
-- Apple MacOSX 10.10 or better
-- 4G RAM
-- 10G HD space
+* Apple MacOSX 10.10 or better
+* 4G RAM
+* 10G HD space
 
 ### Linux
 
-- ubuntu (and flavors) or centos, debian, fedora, rocky on x64
-- 4G RAM
-- 10G HD space
+* ubuntu (and flavors) or centos, debian, fedora, rocky on x64
+* 4G RAM
+* 10G HD space
 
 ## User Installation
 
@@ -70,13 +70,17 @@ From the Releases tab, download the CrossMgr-VERSION.dmg file. From the finder, 
 
 If you still get a message that the dmg file is damaged and to delete it, you will need to temporarily disable GateKeeper to complete the install.  To do so, open a Terminal and enter:
 
-    sudo spctl --master-disable
-    
+```bash
+sudo spctl --master-disable
+```
+
 Then, double-click on the CrossMgr .dmg file.
 
 Re-enable GateKeeper from the terminal as follows:
 
-    sudo spctl --master-enable
+```bash
+sudo spctl --master-enable
+```
 
 Some Mac OSX versions accept pressing CTRL before clicking on the app for the first time, and then clicking open.
 The app is non-signed and MacOSX may not open it otherwise.
@@ -157,19 +161,19 @@ Linux dependancies are contained in the linuxdeps.sh script.
 
 The build procedure for Linux and MacOSX platforms are as follows:
 
-- Install the Linux dependancies (Linux only!)
+* Install the Linux dependancies (Linux only!)
 
 ```bash
-  bash linuxdeps.sh
+bash linuxdeps.sh
 ```
 
-- Setup a virtual env, download the required python modules:
+* Setup a virtual env, download the required python modules:
 
 ```bash
 bash compile.sh -S
 ```
 
-- Build all the code and publish to releases directory
+* Build all the code and publish to releases directory
 
 ```bash
 bash compile.sh -a -A
@@ -179,17 +183,19 @@ When the build is complete, the resultant DMG/AppImage files will be in the rele
 
 The build procedure for windows are as follows:
 
-- Setup a virtual env, download the required python modules:
+* Setup a virtual env, download the required python modules:
 
 ```powershell
+`virtualenv env`
 .\compile.ps1 -setupenv
 ```
 
-- Build all the code and publish to releases directory
+* Build all the code and publish to releases directory
 
 ```powershell
 .\compile.ps1 -all -everything
 ```
+
 When the build is complete, the resultant exe installer files will be in the release directory. The above process is what the build.yml Workflow file (.github/workflows/devbuild.yaml) uses to build the code on GitHub.
 
 ### Making a Release
@@ -219,4 +225,3 @@ Windows:
 You must be on the dev branch without any pending changes to make a release. If the version number of an application is to be incremented, it should be done in the dev branch, and checked in prior to making the release.
 
 A build can also be forced by tagging the master branch.  This is done with the -T option (Linux/Mac) and -tag (windows). You can only tag the master branch with this option.
-

--- a/compile.ps1
+++ b/compile.ps1
@@ -199,9 +199,10 @@ function BuildLocale($program)
 	foreach ($locale in $locales)
 	{
 		$pofile="$localepath\$locale\LC_MESSAGES\messages.po"
+		$lVal = Split-Path $locale -Leaf
 		Write-Host "Building Locale: $locale"
-		Write-Host "python -mbabel compile -f -d $localepath -l $locale -i $pofile"
-		Start-Process -Wait -NoNewWindow -FilePath "python.exe" -ArgumentList "-mbabel compile -f -d $localepath -l $locale -i $pofile"
+		Write-Host "pybabel compile -f -d $localepath -l $locale -i $pofile"
+		Start-Process -Wait -NoNewWindow -FilePath "pybabel.exe" -ArgumentList "compile -f -d $localepath -l $lVal -i $pofile"
 		if ($? -eq $false)
 		{
 			Write-Host "Locale $locale failed. Aborting..."

--- a/compile.ps1
+++ b/compile.ps1
@@ -285,6 +285,92 @@ function CopyAssets($program)
 	}
 }
 
+function GetProgramFilesDirs()
+{
+	$drives = (Get-PSDrive -PSProvider FileSystem | Where-Object Name -ne 'Temp').Root
+	$searchProgramFilesDirs = @('Program Files', 'Program Files (x86)')
+	$dirs = @()
+	foreach ($drive in $drives)
+	{
+		foreach ($dir in $searchProgramFilesDirs)
+		{
+			$checkDir = "$drive\$dir\Inno Setup 6"
+			if (Test-Path -Path $checkDir)
+			{
+				$dirs += $checkDir
+			}
+		}
+	}
+	return $dirs
+}
+
+function GetInnoRegistryDir()
+{
+	$apps=(Get-ChildItem HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\* | % { Get-ItemProperty $_.PsPath } | Select DisplayName, InstallLocation | Sort-Object Displayname -Descending)
+
+	foreach ($app in $apps)
+	{
+		if ($app.DisplayName -like 'Inno Setup version 6*')
+		{
+			return $app.InstallLocation
+		}
+	}
+	return $null
+}
+
+function GetInnoSearchDirs($printOutput)
+{
+	$searchDirs = @()
+
+	# Scan the registry for innosetup 6.x
+	$regpath = GetInnoRegistryDir
+	if (![string]::IsNullOrEmpty($regpath))
+	{
+		if ($printOutput -eq $true)
+		{
+			Write-Host "InnoSetup 6 is defined in registry as installed at $regpath"
+		}
+		$searchDirs += $regpath
+	}
+
+	$pfdirs = GetProgramFilesDirs
+	$searchDirs = $searchDirs + $pfdirs
+	$searchDirs += "$env:LOCALAPPDATA\Programs\Inno Setup 6"
+	$searchDirs += "$env:APPDATA\Programs\Inno Setup 6"
+	return $searchDirs
+}
+
+function GetInnoDir()
+{
+	$searchDirs = GetInnoSearchDirs
+	foreach ($innolocation in $searchDirs) {
+		if (Test-Path -Path $innolocation) {
+			return $innolocation
+		}
+	}
+	return $null
+}
+
+function CheckInnoSetupAvailable($printFoundOutput)
+{
+	$innolocation = GetInnoDir
+	if (![string]::IsNullOrEmpty($innolocation))
+	{
+		$inno = "${innolocation}\ISCC.exe"
+		if (Test-Path -Path "$inno" -PathType Leaf)
+		{
+			if ($printFoundOutput -eq $true)
+			{
+				Write-Host "Found InnoSetup 6 installed at $innolocation"
+			}
+			return $inno
+		}
+	}
+
+	Write-Host "Cant find Inno Setup 6.x! Is it installed? Aborting...."
+	exit 1
+}
+
 function Package($program)
 {
 	$builddir = GetBuildDir($program)
@@ -317,47 +403,9 @@ OutputBaseFilename=$newinstallname
 OutputDir=$releasepath
 "
 	Set-Content -Path "$builddir\inno_setup.txt" -Value "$setup"
-	# Scan the registry for innosetup 6.x
-	$apps=(Get-ChildItem HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\* | % { Get-ItemProperty $_.PsPath } | Select DisplayName, InstallLocation | Sort-Object Displayname -Descending)
-	foreach ($app in $apps)
-	{
-		if ($app.DisplayName -like 'Inno Setup version 6*')
-		{
-			$innolocaton = $app.InstallLocation
-			break
-		}
-	}
-	if (![string]::IsNullOrEmpty($innolocaton) -and (Test-Path -Path $innolocaton))
-	{
-		Write-Host "InnoSetup 6 installed $innolocaton (registry)"
-	}
-	elseif (Test-Path -Path 'C:\Program Files (x86)\Inno Setup 6')
-	{
-		$innolocaton = 'C:\Program Files (x86)\Inno Setup 6\'
-		Write-Host "InnoSetup 6 installed $innolocaton (directory)"
-	}
-	elseif (Test-Path -Path 'C:\Program Files\Inno Setup 6')
-	{
-		$innolocaton = 'C:\Program Files\Inno Setup 6\'
-		Write-Host "InnoSetup 6 installed $innolocaton (directory)"
-	}
-	elseif (Test-Path -Path 'D:\Program Files (x86)\Inno Setup 6')
-	{
-		$innolocaton = 'D:\Program Files (x86)\Inno Setup 6\'
-		Write-Host "InnoSetup 6 installed $innolocaton (directory)"
-	}
-	elseif (Test-Path -Path 'D:\Program Files\Inno Setup 6')
-	{
-		$innolocaton = 'D:\Program Files\Inno Setup 6\'
-		Write-Host "InnoSetup 6 installed $innolocaton (directory)"
-	}
-	else
-	{
-		Write-Host "Cant find Inno Setup 6.x! Is it installed? Aborting...."
-		exit 1
-	}
-	
-	$inno = "${innolocaton}ISCC.exe"
+
+	$inno = CheckInnoSetupAvailable
+
 	Write-Host "$inno"  "${builddir}\${program}.iss"
 	
 	$iss = "${builddir}\${program}.iss"
@@ -819,6 +867,7 @@ if ($everything -eq $false)
 }
 else
 {
+	$_inno = CheckInnoSetupAvailable
 	BuildAll($programs)
 }
 if ($virus -eq $true)

--- a/compile.sh
+++ b/compile.sh
@@ -444,7 +444,7 @@ tagrepo() {
 
 dorelease() {
 	CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD -- | head -1)
-	if [[ ! "$CURRENT_BRANCH" =~ ^dev ]]; then
+	if [[ ! "$CURRENT_BRANCH" =~ ^dev\/ ]]; then
 		echo "Unable to do release on $CURRENT_BRANCH branch. You must be on dev branch to cut a release".
         exit 1
 	fi

--- a/compile.sh
+++ b/compile.sh
@@ -112,11 +112,11 @@ downloadAppImage() {
 
 compileCode() {
     fixDependencies
-    
+
 	PROGRAM=$1
 	getBuildDir $PROGRAM
     checkEnvActive
-    
+
 	echo "Compiling code"
 	python3 -mcompileall -l $BUILDDIR
 	if [ $? -ne 0 ]; then
@@ -147,10 +147,10 @@ buildLocale() {
 
 buildHelp() {
 	PROGRAM=$1
-	
+
 	cd "$PROGRAM"
-	
-	if [ -f "buildhelp.py" ]; then	
+
+	if [ -f "buildhelp.py" ]; then
 		if [ -d "$PROGRAM"HelpIndex ]; then
 			rm -rf "$PROGRAM"HelpIndex
 		fi
@@ -162,7 +162,7 @@ buildHelp() {
 			exit 1
 		fi
 	fi
-	
+
 	cd ..
 }
 
@@ -213,7 +213,7 @@ copyAssets() {
 	else
 		buildHelp $PROGRAM
 	fi
-	
+
 
 	# Copy help files last to wait for them to be built by now.
 	if [ -d "${BUILDDIR}/${PROGRAM}HtmlDoc" ]; then
@@ -293,7 +293,7 @@ envSetup() {
 	else
 		echo "Already using $VIRTUAL_ENV"
 	fi
-	
+
 	if   [ $OSNAME == "Linux" ]; then
         # On Linux, the wxPython module install attempts to rebuild the module from the C/C++ source.
         # Unfortunately, this always fails in an virtualenv and/or there are other missing C/C++ libraries.
@@ -302,7 +302,7 @@ envSetup() {
 
 		# Old way, but lsb_release is not always included in Linux, so this can fail.
 		# UBUNTU_RELEASE=`lsb_release -r | awk '{ print $2 }'`
-		
+
 		# New way.  Get version information from /etc/os-release.  Ignore the third version value (if present).
 		UBUNTU_RELEASE=$(awk '/^VERSION_ID\s*=/{ gsub(/[^0-9.]/,"",$0); split($0, v, "."); print v[1] "." v[2] }' /etc/os-release)
 		if [ $? -ne 0 ]; then
@@ -313,12 +313,12 @@ envSetup() {
 	else
 		pip3 install -v -r requirements.txt
 	fi
-	
+
     if [ $? -ne 0 ]; then
         echo "Pip requirements install failed. Aborting..."
         exit 1
     fi
-    
+
     if   [ $OSNAME == "Windows" ]; then
 		pip3 install pywin32
 	fi
@@ -412,7 +412,7 @@ listFiles() {
 
 fixDependencies() {
 	PROGRAM=$1
-	
+
 	if [ -f "$PROGRAM/UpdateDependencies.py" ]; then
 		echo "Fixing: $PROGRAM"
 		cd $PROGRAM
@@ -444,7 +444,7 @@ tagrepo() {
 
 dorelease() {
 	CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD -- | head -1)
-	if [ "$CURRENT_BRANCH" != "dev" ]; then
+	if [[ ! "$CURRENT_BRANCH" =~ ^dev ]]; then
 		echo "Unable to do release on $CURRENT_BRANCH branch. You must be on dev branch to cut a release".
         exit 1
 	fi
@@ -525,7 +525,7 @@ do
 	case ${option} in
 		h) doHelp
 		;;
-		a) 
+		a)
  		    PROGRAMS="StageRaceGC CallupSeedingMgr CrossMgrImpinj TagReadWrite SeriesMgr CrossMgrAlien CrossMgrVideo PointsRaceMgr SprintMgr CrossMgr"
 		;;
 		c) PROGRAMS="$PROGRAMS CrossMgr"

--- a/compile.sh
+++ b/compile.sh
@@ -444,9 +444,9 @@ tagrepo() {
 
 dorelease() {
 	CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD -- | head -1)
-	if [[ ! "$CURRENT_BRANCH" =~ ^dev\/ ]]; then
-		echo "Unable to do release on $CURRENT_BRANCH branch. You must be on dev branch to cut a release".
-        exit 1
+	if [ "$CURRENT_BRANCH" != "dev" ]; then
+    echo "Unable to do release on $CURRENT_BRANCH branch. You must be on dev branch to cut a release".
+    exit 1
 	fi
     if ! git diff-index --quiet HEAD --; then
         echo "$CURRENT_BRANCH has uncommited changed. Refusing to release. Commit your code."

--- a/compile.sh
+++ b/compile.sh
@@ -136,8 +136,9 @@ buildLocale() {
 	do
 		pofile="${locale}/LC_MESSAGES/messages.po"
 		echo "Building Locale: $locale"
-		echo "python -mbabel compile -f -d $localepath -l $locale -i $pofile"
-		python -mbabel compile -f -d $localepath -l $locale -i $pofile
+		lVal = $(basename $locale)
+		echo "pybabel compile -f -d $localepath -l $lVal -i $pofile"
+		pybabel compile -f -d $localepath -l $lVal -i $pofile
 		if [ $? -ne 0 ]; then
 			echo "Locale $locale failed. Aborting..."
 			exit 1

--- a/compile.sh
+++ b/compile.sh
@@ -136,7 +136,7 @@ buildLocale() {
 	do
 		pofile="${locale}/LC_MESSAGES/messages.po"
 		echo "Building Locale: $locale"
-		lVal = $(basename $locale)
+		lVal=$(basename $locale)
 		echo "pybabel compile -f -d $localepath -l $lVal -i $pofile"
 		pybabel compile -f -d $localepath -l $lVal -i $pofile
 		if [ $? -ne 0 ]; then

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,1 +1,0 @@
-setuptools==58.2.0

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,1 @@
+setuptools==58.2.0

--- a/linuxdeps.sh
+++ b/linuxdeps.sh
@@ -5,4 +5,4 @@ sudo apt update
 # sudo apt install libjpeg9 libtiff5 libsdl2-2.0-0 libnotify-bin freeglut3 libsm6 libgtk-3-0 libwebkitgtk-3.0-0 libgstreamer1.0-0 libgtk-3-dev python3.9-dev
 
 # Some libraries are still required for wxPython.
-sudo apt install libsdl2-2.0-0 libgtk-3-0 libgtk-3-dev
+sudo apt install $* libsdl2-2.0-0 libgtk-3-0 libgtk-3-dev

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,6 @@ paramiko
 markdown
 bs4
 trueskill
-pybabel
 opencv-python
 pyinstaller
 piexif
@@ -27,3 +26,4 @@ virustotal-api
 metaphone
 pyllrp
 wxPython
+babel

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ virustotal-api
 metaphone
 pyllrp
 wxPython
+babel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 wheel
 numpy
-setuptools
+setuptools==58.2.0
 requests
 waitress
 xlsxwriter
@@ -26,4 +26,3 @@ virustotal-api
 metaphone
 pyllrp
 wxPython
-setuptools==58.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 wheel
 numpy
-setuptools==58.2.0
+setuptools
 requests
 waitress
 xlsxwriter

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ virustotal-api
 metaphone
 pyllrp
 wxPython
+setuptools==58.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 wheel
 numpy
-setuptools
+setuptools==58.2.0
 requests
 waitress
 xlsxwriter
@@ -27,4 +27,3 @@ virustotal-api
 metaphone
 pyllrp
 wxPython
-setuptools==58.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ virustotal-api
 metaphone
 pyllrp
 wxPython
+setuptools==58.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ paramiko
 markdown
 bs4
 trueskill
+pybabel
 opencv-python
 pyinstaller
 piexif
@@ -26,4 +27,3 @@ virustotal-api
 metaphone
 pyllrp
 wxPython
-babel

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,6 @@ paramiko
 markdown
 bs4
 trueskill
-pybabel
 opencv-python
 pyinstaller
 piexif


### PR DESCRIPTION
Removes hard-coded locations to look for InnoSetup, and now checks the registry path (if found), then 'Program Files' and 'Program Files (x86)' on all available drive letters, and then the User AppLocal and Local\Programs directories, and iterates through that list until the executable is found.

The check has also been moved to the first step of the build process when -Everything is specified, and fails fast if InnoSetup is not installed.