### PR TITLE
Add Safe date picker to prevent crash on large year value

### DIFF
--- a/CrossMgrVideo/MainWin.py
+++ b/CrossMgrVideo/MainWin.py
@@ -22,6 +22,8 @@ import sqlite3
 from time import sleep
 from queue import Queue
 
+from DatePicker import SafeDatePickerCtrl
+
 from datetime import datetime, timedelta, time
 
 now = datetime.now
@@ -580,7 +582,7 @@ class MainWin( wx.Frame ):
 		hsDate = wx.BoxSizer( wx.HORIZONTAL )
 		hsDate.Add( wx.StaticText(self, label='Show Triggers for'), flag=wx.ALIGN_CENTER_VERTICAL )
 		tQuery = now()
-		self.date = wx.adv.DatePickerCtrl(
+		self.date = SafeDatePickerCtrl(
 			self,
 			dt=wx.DateTime.FromDMY( tQuery.day, tQuery.month-1, tQuery.year ),
 			style=wx.adv.DP_DROPDOWN|wx.adv.DP_SHOWCENTURY

--- a/CrossMgrVideo/ManageDatabase.py
+++ b/CrossMgrVideo/ManageDatabase.py
@@ -3,7 +3,7 @@ import wx.adv
 import os
 import datetime
 
-DatePickerCtrl = wx.adv.DatePickerCtrl
+from DatePicker import SafeDatePickerCtrl
 
 class ManageDatabase( wx.Dialog ):
 	def __init__( self, parent, dbSize, dbName, trigFirst, trigLast, id=wx.ID_ANY, title='', size=wx.DefaultSize, style=wx.DEFAULT_DIALOG_STYLE ):
@@ -40,7 +40,7 @@ class ManageDatabase( wx.Dialog ):
 		hs = wx.BoxSizer( wx.HORIZONTAL )
 		hs.Add( wx.StaticText(self, label='Delete all data (inclusive) from'), flag=wx.ALIGN_CENTER_VERTICAL )
 		tQuery = datetime.datetime.now() - datetime.timedelta(days=7)
-		self.dateFrom = DatePickerCtrl(
+		self.dateFrom = SafeDatePickerCtrl(
 			self,
 			dt=wx.DateTime.FromDMY( tQuery.day, tQuery.month-1, tQuery.year ),
 			style=wx.adv.DP_DROPDOWN|wx.adv.DP_SHOWCENTURY|wx.adv.DP_ALLOWNONE
@@ -49,7 +49,7 @@ class ManageDatabase( wx.Dialog ):
 		
 		hs.Add( wx.StaticText(self, label='to'), flag=wx.ALIGN_CENTER_VERTICAL|wx.LEFT, border=4 )
 		tQuery = datetime.datetime.now() - datetime.timedelta(days=1)
-		self.dateTo = DatePickerCtrl(
+		self.dateTo = SafeDatePickerCtrl(
 			self,
 			dt=wx.DateTime.FromDMY( tQuery.day, tQuery.month-1, tQuery.year ),
 			style=wx.adv.DP_DROPDOWN|wx.adv.DP_SHOWCENTURY|wx.adv.DP_ALLOWNONE

--- a/DatePicker.py
+++ b/DatePicker.py
@@ -1,0 +1,31 @@
+from typing import Any
+
+import wx, wx.adv
+from wx.adv import DatePickerCtrl
+
+import Utils
+
+class SafeDatePickerCtrl(DatePickerCtrl):
+	def __init__(self,
+             *args: Any,
+             **kw: Any) -> None:
+		style = kw.pop('style', wx.adv.DP_DROPDOWN)
+		dt = kw.pop('dt', Utils.GetDateTimeToday())
+		super().__init__(style=style, dt=dt, *args, **kw)
+
+		currentRange = self.GetRange()
+		if not currentRange or not len(currentRange) == 2:
+			minRange = wx.DateTime.FromDMY(1, 0, 1900)
+			maxRange = wx.DateTime.FromDMY(1, 0, 2200)
+		else:
+			minRange = currentRange[1].Value
+			maxRange = currentRange[2].Value
+
+		if currentRange[2].Inv_Year < 1601:
+			maxRange = wx.DateTime.FromDMY(1, 0, 2200)
+
+		super().SetRange(
+			dt1=minRange,
+			dt2=maxRange
+		)
+

--- a/PointsRaceMgr/Configure.py
+++ b/PointsRaceMgr/Configure.py
@@ -4,6 +4,8 @@ import datetime
 
 import wx
 import wx.adv
+
+from DatePicker import SafeDatePickerCtrl
 from NumCtrl import PosNumCtrl
 import wx.lib.intctrl as IC
 
@@ -36,7 +38,7 @@ class Configure( wx.Panel ):
 		hs = wx.BoxSizer( wx.HORIZONTAL )
 		label = wx.StaticText( self, label='Date:' )
 		hs.Add( label, flag=wx.ALIGN_CENTER_VERTICAL|wx.LEFT, border=16 )
-		ctrl = wx.adv.DatePickerCtrl( self, style = wx.adv.DP_DROPDOWN | wx.adv.DP_SHOWCENTURY, size=(132,-1) )
+		ctrl = SafeDatePickerCtrl( self, style = wx.adv.DP_DROPDOWN | wx.adv.DP_SHOWCENTURY, size=(132,-1) )
 		ctrl.Bind( wx.adv.EVT_DATE_CHANGED, self.onChange )
 		hs.Add( ctrl, flag=wx.ALIGN_LEFT|wx.ALIGN_CENTER_VERTICAL|wx.LEFT, border=4 )
 		self.dateLabel = label

--- a/RaceDB.py
+++ b/RaceDB.py
@@ -1,6 +1,6 @@
 import re
 import os
-import wx
+import wx, wx.adv
 import wx.dataview as dataview
 import requests
 import datetime
@@ -11,6 +11,8 @@ import urllib.parse
 import Utils
 import Model
 from AddExcelInfo		import getInfo
+from DatePicker import SafeDatePickerCtrl
+
 
 def GetRaceDBConfigFile():
 	return os.path.join( os.path.expanduser('~'), 'CrossMgrRaceDB.ini' )
@@ -223,7 +225,7 @@ class RaceDB( wx.Dialog ):
 		self.raceDBUrl.Bind( wx.EVT_TEXT_ENTER, self.onChange )
 		self.raceDBUrl.SetDropTarget(URLDropTarget(self.raceDBUrl, self.refresh))
 		raceDBLogo.SetDropTarget(URLDropTarget(self.raceDBUrl, self.refresh))
-		self.datePicker = wx.adv.DatePickerCtrl(
+		self.datePicker = SafeDatePickerCtrl(
 			self,
 			size=(120,-1),
 			dt=Utils.GetDateTimeToday(),

--- a/SprintMgr/FieldDef.py
+++ b/SprintMgr/FieldDef.py
@@ -2,7 +2,7 @@ import re
 import datetime
 
 import wx
-from wx.adv import DatePickerCtrl
+from DatePicker import SafeDatePickerCtrl
 from wx.lib.intctrl import IntCtrl
 from wx.lib.masked.numctrl import NumCtrl
 from wx.lib.masked import TimeCtrl, EVT_TIMEUPDATE
@@ -74,7 +74,7 @@ class FieldDef:
 			self.editCtrl.Bind( wx.EVT_TEXT, self.onChanged )
 			
 		elif self.type == FieldDef.DateType:
-			self.editCtrl = DatePickerCtrl( parent, style = wx.adv.DP_DROPDOWN | wx.adv.DP_SHOWCENTURY, size=(120,-1))
+			self.editCtrl = SafeDatePickerCtrl( parent, style = wx.adv.DP_DROPDOWN | wx.adv.DP_SHOWCENTURY, size=(120,-1))
 			self.editCtrl.Bind( wx.adv.EVT_DATE_CHANGED, self.onChanged )
 			
 		elif self.type == FieldDef.TimeType:


### PR DESCRIPTION
When a large year value is entered on Windows, the wx.adv control may cause a crash on Windows.