### PR TITLE
Fix Inno Setup paths

### DIFF
--- a/compile.ps1
+++ b/compile.ps1
@@ -285,6 +285,92 @@ function CopyAssets($program)
 	}
 }
 
+function GetProgramFilesDirs()
+{
+	$drives = (Get-PSDrive -PSProvider FileSystem | Where-Object Name -ne 'Temp').Root
+	$searchProgramFilesDirs = @('Program Files', 'Program Files (x86)')
+	$dirs = @()
+	foreach ($drive in $drives)
+	{
+		foreach ($dir in $searchProgramFilesDirs)
+		{
+			$checkDir = "$drive\$dir\Inno Setup 6"
+			if (Test-Path -Path $checkDir)
+			{
+				$dirs += $checkDir
+			}
+		}
+	}
+	return $dirs
+}
+
+function GetInnoRegistryDir()
+{
+	$apps=(Get-ChildItem HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\* | % { Get-ItemProperty $_.PsPath } | Select DisplayName, InstallLocation | Sort-Object Displayname -Descending)
+
+	foreach ($app in $apps)
+	{
+		if ($app.DisplayName -like 'Inno Setup version 6*')
+		{
+			return $app.InstallLocation
+		}
+	}
+	return $null
+}
+
+function GetInnoSearchDirs($printOutput)
+{
+	$searchDirs = @()
+
+	# Scan the registry for innosetup 6.x
+	$regpath = GetInnoRegistryDir
+	if (![string]::IsNullOrEmpty($regpath))
+	{
+		if ($printOutput -eq $true)
+		{
+			Write-Host "InnoSetup 6 is defined in registry as installed at $regpath"
+		}
+		$searchDirs += $regpath
+	}
+
+	$pfdirs = GetProgramFilesDirs
+	$searchDirs = $searchDirs + $pfdirs
+	$searchDirs += "$env:LOCALAPPDATA\Programs\Inno Setup 6"
+	$searchDirs += "$env:APPDATA\Programs\Inno Setup 6"
+	return $searchDirs
+}
+
+function GetInnoDir()
+{
+	$searchDirs = GetInnoSearchDirs
+	foreach ($innolocation in $searchDirs) {
+		if (Test-Path -Path $innolocation) {
+			return $innolocation
+		}
+	}
+	return $null
+}
+
+function CheckInnoSetupAvailable($printFoundOutput)
+{
+	$innolocation = GetInnoDir
+	if (![string]::IsNullOrEmpty($innolocation))
+	{
+		$inno = "${innolocation}\ISCC.exe"
+		if (Test-Path -Path "$inno" -PathType Leaf)
+		{
+			if ($printFoundOutput -eq $true)
+			{
+				Write-Host "Found InnoSetup 6 installed at $innolocation"
+			}
+			return $inno
+		}
+	}
+
+	Write-Host "Cant find Inno Setup 6.x! Is it installed? Aborting...."
+	exit 1
+}
+
 function Package($program)
 {
 	$builddir = GetBuildDir($program)
@@ -317,47 +403,9 @@ OutputBaseFilename=$newinstallname
 OutputDir=$releasepath
 "
 	Set-Content -Path "$builddir\inno_setup.txt" -Value "$setup"
-	# Scan the registry for innosetup 6.x
-	$apps=(Get-ChildItem HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\* | % { Get-ItemProperty $_.PsPath } | Select DisplayName, InstallLocation | Sort-Object Displayname -Descending)
-	foreach ($app in $apps)
-	{
-		if ($app.DisplayName -like 'Inno Setup version 6*')
-		{
-			$innolocaton = $app.InstallLocation
-			break
-		}
-	}
-	if (![string]::IsNullOrEmpty($innolocaton) -and (Test-Path -Path $innolocaton))
-	{
-		Write-Host "InnoSetup 6 installed $innolocaton (registry)"
-	}
-	elseif (Test-Path -Path 'C:\Program Files (x86)\Inno Setup 6')
-	{
-		$innolocaton = 'C:\Program Files (x86)\Inno Setup 6\'
-		Write-Host "InnoSetup 6 installed $innolocaton (directory)"
-	}
-	elseif (Test-Path -Path 'C:\Program Files\Inno Setup 6')
-	{
-		$innolocaton = 'C:\Program Files\Inno Setup 6\'
-		Write-Host "InnoSetup 6 installed $innolocaton (directory)"
-	}
-	elseif (Test-Path -Path 'D:\Program Files (x86)\Inno Setup 6')
-	{
-		$innolocaton = 'D:\Program Files (x86)\Inno Setup 6\'
-		Write-Host "InnoSetup 6 installed $innolocaton (directory)"
-	}
-	elseif (Test-Path -Path 'D:\Program Files\Inno Setup 6')
-	{
-		$innolocaton = 'D:\Program Files\Inno Setup 6\'
-		Write-Host "InnoSetup 6 installed $innolocaton (directory)"
-	}
-	else
-	{
-		Write-Host "Cant find Inno Setup 6.x! Is it installed? Aborting...."
-		exit 1
-	}
-	
-	$inno = "${innolocaton}ISCC.exe"
+
+	$inno = CheckInnoSetupAvailable
+
 	Write-Host "$inno"  "${builddir}\${program}.iss"
 	
 	$iss = "${builddir}\${program}.iss"
@@ -819,6 +867,7 @@ if ($everything -eq $false)
 }
 else
 {
+	$_inno = CheckInnoSetupAvailable
 	BuildAll($programs)
 }
 if ($virus -eq $true)


### PR DESCRIPTION
Rework InnoSetup path checks. Ensure InnoSetup is available before starting build.

Removes hard-coded locations to look for InnoSetup, and now checks the registry path (if found), then 'Program Files' and 'Program Files (x86)' on all available drive letters, and then the User AppLocal and Local\Programs directories, and iterates through that list until the executable is found.

The check has also been moved to the first step of the build process when -Everything is specified, and fails fast if InnoSetup is not installed.